### PR TITLE
Fixed a typo

### DIFF
--- a/examples/archive.html
+++ b/examples/archive.html
@@ -123,7 +123,7 @@
           }
         })
         .catch((error) => {
-          responseText.innerHTML = 'Uh-oh! Something\'s not right with the link provided!'
+          responseText.innerHTML = `Uh-oh! Something's not right with the link provided!`
         })
         .finally(() => {
           bootstrap.Modal.getInstance(welcomeModal).hide();


### PR DESCRIPTION
Fixed a typo in line 126 of examples/archive.html by replacing this -->

126  responseText.innerHTML = 'Uh-oh! Something\'s not right with the link provided!' 

With this -->

126  responseText.innerHTML = `Uh-oh! Something's not right with the link provided!`

Fixes #0000 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updates
* [ ] @mention the original creator of the issue in a comment below for help or for a review

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
